### PR TITLE
fix(VAutocomplete): fix accessibility issues

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -574,6 +574,7 @@ export const VAutocomplete = genericComponent<new <
                 { props.menuIcon ? (
                   <VIcon
                     class="v-autocomplete__menu-icon"
+                    aria-hidden="true"
                     icon={ props.menuIcon }
                     onMousedown={ onMousedownMenuIcon }
                     onClick={ noop }

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -408,6 +408,7 @@ export const VAutocomplete = genericComponent<new <
             },
             props.class,
           ]}
+          roleType="combobox"
           style={ props.style }
           readonly={ props.readonly }
           placeholder={ isDirty ? undefined : props.placeholder }

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -194,7 +194,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                 onClick:clear={ onClear }
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
-                role="textbox"
+                role={ attrs.roleType || "textbox" }
                 { ...fieldProps }
                 id={ id.value }
                 active={ isActive.value || isDirty.value }


### PR DESCRIPTION
## Description
1) .v-autocomplete__menu-icon (the drowdown icon) should be hidden from screen readers so I am setting aria-hidden to true
   - This change is fixing the following AXE issue:
      Ensures every ARIA button, link and menuitem has an accessible name
2) role has to be comobox for autocompletes but that's being set in VTextField so I am passing in roleType to VTextField. When roleType is defined, the role will be combox if not it will be textbox so it shouldn't affect other components that are using VTextField (including VTextField)
  - This change is fixing:
     Ensures ARIA attributes are allowed for an element's role

resolves part of #17629

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        placeholder="Test Autocomplete"
        persistent-placeholder
        :items="itemsForSelect"
        aria-label="Testing Aria Label"
        item-value="Test Value"
        item-title="Test Value"
        density="compact"
        variant="outlined"
        clearable
      />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',

    setup () {
      const itemsForSelect = ['one', 'two', 'three']
      return {
        itemsForSelect,
      }
    },
  }
</script>

```
